### PR TITLE
Fix crash when compiled against qt5

### DIFF
--- a/mts/transport/usb/mtptransporterusb.h
+++ b/mts/transport/usb/mtptransporterusb.h
@@ -113,6 +113,7 @@ class MTPTransporterUSB : public MTPTransporter
         ControlReaderThread     m_ctrl;         ///< Threaded IO for Control EP
         BulkReaderThread        m_bulkRead;     ///< Threaded Reader for Bulk Out EP
         BulkWriterThread        m_bulkWrite;    ///< Threaded Writer for Bulk In EP
+        bool                    m_writer_busy;
         InterruptWriterThread   m_intrWrite;    ///< Threaded Writer for Interrupt EP
 
     public Q_SLOTS:

--- a/mts/transport/usb/threadio.h
+++ b/mts/transport/usb/threadio.h
@@ -74,13 +74,14 @@ public:
 
     void setData(const quint8 *buffer, quint32 dataLen);
     void run();
+    bool resultReady();
     bool getResult();
     void exitThread();
 
-    QMutex m_lock;
 private:
     const quint8 *m_buffer;
     quint32 m_dataLen;
+    QAtomicInt m_result_ready;
     bool m_result;
 };
 


### PR DESCRIPTION
qt5 disallows unlocking an already-unlocked mutex. Fixed the logic for the BulkWriter thread. There's more cleanup to do for reliability but this way it at least runs.
