### PR TITLE
Fix the storage-test unit tests

### DIFF
--- a/mts/platform/storage/fsstorageplugin/fsstorageplugin.cpp
+++ b/mts/platform/storage/fsstorageplugin/fsstorageplugin.cpp
@@ -935,8 +935,8 @@ MTPResponseCode FSStoragePlugin::addItem( ObjHandle &parentHandle, ObjHandle &ha
 MTPResponseCode FSStoragePlugin::deleteItem( const ObjHandle& handle, const MTPObjFormatCode& formatCode )
 {
     // If handle == 0xFFFFFFFF, that means delete all objects that can be deleted ( this could be filered by fmtCode )
-    quint32 totalNoOfObjects = m_objectHandlesMap.count() - 1;
-    quint32 noOfObjectsByFormat = 0;
+    bool deletedSome = false;
+    bool failedSome = false;
     StorageItem *storageItem = 0;
     MTPResponseCode response = MTP_RESP_GeneralError;
 
@@ -951,13 +951,23 @@ MTPResponseCode FSStoragePlugin::deleteItem( const ObjHandle& handle, const MTPO
                 storageItem = i.value();
                 if( storageItem->m_objectInfo && storageItem->m_objectInfo->mtpObjectFormat == formatCode )
                 {
-                    ++noOfObjectsByFormat;
                     response = deleteItemHelper( i.key() );
                 }
             }
             else
             {
                 response = deleteItemHelper( i.key() );
+            }
+            if( MTP_RESP_OK == response)
+            {
+                deletedSome = true;
+            }
+            else if (MTP_RESP_InvalidObjectHandle != response)
+            {
+                // "invalid object handle" is not a failure because it
+                // just means this item was deleted as part of a folder
+                // before the loop got to it.
+                failedSome = true;
             }
         }
     }
@@ -966,19 +976,14 @@ MTPResponseCode FSStoragePlugin::deleteItem( const ObjHandle& handle, const MTPO
         response = deleteItemHelper( handle );
     }
 
-    if( MTP_RESP_OK == response && 0xFFFFFFFF == handle )
+    /* MTPv1.1 D.2.11 DeleteObject
+     * "If a value of 0xFFFFFFFF is passed in the first parameter, and
+     * some subset of objects are not deleted (but at least one object is
+     * deleted), a response of Partial_Deletion shall be returned."
+     */
+    if( 0xFFFFFFFF == handle && deletedSome && failedSome)
     {
-        if( formatCode && MTP_OBF_FORMAT_Undefined != formatCode )
-        {
-            if( noOfObjectsByFormat + m_objectHandlesMap.count() - 1 != totalNoOfObjects )
-            {
-                response = MTP_RESP_PartialDeletion;
-            }
-        }
-        else if( m_objectHandlesMap.count() != 1 )
-        {
-            response = MTP_RESP_PartialDeletion;
-        }
+        response = MTP_RESP_PartialDeletion;
     }
 
     return response;
@@ -1002,6 +1007,12 @@ MTPResponseCode FSStoragePlugin::deleteItemHelper( const ObjHandle& handle, bool
     if( !storageItem )
     {
         return MTP_RESP_GeneralError;
+    }
+
+    // Allowing deletion of the root is too dangerous (might be $HOME)
+    if( storageItem == m_root )
+    {
+        return MTP_RESP_ObjectWriteProtected;
     }
 
     // If this is a file or an empty dir, just delete this item.

--- a/mts/platform/storage/fsstorageplugin/unittests/fsstorageplugin_test.cpp
+++ b/mts/platform/storage/fsstorageplugin/unittests/fsstorageplugin_test.cpp
@@ -248,8 +248,10 @@ void FSStoragePlugin_test::testDeleteAll()
 {
     MTPResponseCode response = MTP_RESP_GeneralError;
 
+    // The storageitem for the root should survive deletion, hence the
+    // PartialDeletion and the remaining item count of 1
     response = m_storage->deleteItem( 0xFFFFFFFF,  MTP_OBF_FORMAT_Undefined );
-    QCOMPARE( response, (MTPResponseCode)MTP_RESP_OK );
+    QCOMPARE( response, (MTPResponseCode)MTP_RESP_PartialDeletion );
 
     QCOMPARE( m_storage->m_objectHandlesMap.size(), 1 );
     QCOMPARE( m_storage->m_objectHandlesMap.size(), m_storage->m_pathNamesMap.size() );


### PR DESCRIPTION
The testDeleteAll() test exposed some bugs in the DeleteObject implementation. The test itself was also buggy though. This PR fixes both, and the other storage-test unit tests now pass too.
