### PR TITLE
[mtp] Increase thumbnail capacity

### DIFF
--- a/mts/platform/storage/fsstorageplugin/thumbnailer.cpp
+++ b/mts/platform/storage/fsstorageplugin/thumbnailer.cpp
@@ -53,7 +53,7 @@ static const QString THUMB_DIR = "/.thumbnails";
 
 
 Thumbnailer::Thumbnailer() :
-    ThumbnailerProxy(THUMBNAILER_SERVICE, THUMBNAILER_GENERIC_PATH, Buteo::SyncDBusConnection::sessionBus()), MAX_REQ_MAP_SIZE(50),
+    ThumbnailerProxy(THUMBNAILER_SERVICE, THUMBNAILER_GENERIC_PATH, Buteo::SyncDBusConnection::sessionBus()), MAX_REQ_MAP_SIZE(2000),
     m_scheduler("foreground"), m_flavor("normal")
 {
     QString thumbBaseDir = QDir::homePath() + THUMB_DIR;


### PR DESCRIPTION
The thumbnailer client was arbitrarily limited to 50 open thumbnail requests.
This was too little when dealing with a directory of 250 photos; some of them remained without thumbnails on the host.
I guess it's good to have _some_ limit, as a safeguard against running out of memory. Arbitrarily increased it to 2000.
