### PR TITLE
[mtp] ignore storage ID sent in MTP object info

### DIFF
--- a/mts/platform/storage/storagefactory.cpp
+++ b/mts/platform/storage/storagefactory.cpp
@@ -256,11 +256,10 @@ StoragePlugin *StorageFactory::storageOfHandle(ObjHandle handle) const
 MTPResponseCode StorageFactory::addItem( quint32& storageId, ObjHandle &parentHandle, ObjHandle &handle, MTPObjectInfo *info ) const
 {
     MTPResponseCode response = MTP_RESP_GeneralError;
-    // Add the item in the right storage.
-    // Responder can choose the storage in this case
-    if( 0x00000000 == info->mtpStorageId )
-    {
-        // Choose the first storage as of now.
+
+    if(storageId == 0x00000000) {
+        // It was left up to us to choose the storage. As of now, pick the first
+        // one.
         // FIXME Not a good idea to just pick the first storage. Maybe we should choose one has enough available space, etc.
         storageId = assignStorageId(1,1);
     }


### PR DESCRIPTION
Some initiators leave this field zero. We should always take into
account only the storage ID parameter of MTP request. Not doing so
resulted in files ending up on the first storage (since ID 0 means
responder should choose), and if parent object was also specified, error
response with InvalidParentObject was generated.
