### PR TITLE
[propertycache] dispose ObjectPropertyCache together with StorageFactory

### DIFF
--- a/mts/platform/storage/storagefactory.h
+++ b/mts/platform/storage/storagefactory.h
@@ -243,7 +243,7 @@ private:
     ObjHandle m_newObjectHandle;
     MtpInt128 m_newPuoid;
 
-    ObjectPropertyCache &m_objectPropertyCache;
+    QScopedPointer<ObjectPropertyCache> m_objectPropertyCache;
 
     /// Improves performance by preventing repeat mass fills of object property
     /// cache with StoragePlugin::getChildPropertyValues().

--- a/mts/protocol/objectpropertycache.cpp
+++ b/mts/protocol/objectpropertycache.cpp
@@ -34,17 +34,6 @@
 
 using namespace meegomtp1dot0;
 
-ObjectPropertyCache* ObjectPropertyCache::instance()
-{
-    MTP_FUNC_TRACE();
-
-    static QScopedPointer<ObjectPropertyCache> instance;
-    if(!instance) {
-        instance.reset(new ObjectPropertyCache);
-    }
-    return instance.data();
-}
-
 void ObjectPropertyCache::add( ObjHandle handle, MTPObjPropertyCode propertyCode, const QVariant &value )
 {
     MTP_FUNC_TRACE();

--- a/mts/protocol/objectpropertycache.h
+++ b/mts/protocol/objectpropertycache.h
@@ -52,9 +52,7 @@ namespace meegomtp1dot0
 class ObjectPropertyCache
 {
     public:
-        /// Returns an instance to the single ObjectPropertyCache object
-        /// \return returns a pointer to the ObjectPropertyCache object
-        static ObjectPropertyCache* instance();
+        ObjectPropertyCache() {}
 
         /// Add/Modify a property-value pair for an object to the cache.
         /// \param handle [in] the object handle which needs to be added/modified
@@ -129,13 +127,8 @@ class ObjectPropertyCache
         ~ObjectPropertyCache();
 
     private:
-        /// Private Constructor
-        ObjectPropertyCache(){}
-
         /// The cache!
         QHash<ObjHandle, QHash<MTPObjPropertyCode,QVariant> > m_propertyMap;
-        /// Pointer to the single instance of this object;
-        static ObjectPropertyCache* m_instance;
 };
 }
 #endif


### PR DESCRIPTION
When the cable was unplugged, the storage factory was disposed but items
in the cache persisted. After some modification of the filesystem while
USB was disconnected, StorageFactory was likely to assign different
object IDs to the files, causing that properties of a wrong object were
retrieved from the cache, still filled from the previous session.

There's now no reason for ObjectPropertyCache to be a singleton. We
let StorageFactory instantiate the cache and delete it at the end of its
own lifetime.
