### PR TITLE
Fix MTP compatibility with some android kernels

### DIFF
--- a/mts/transport/usb/descriptor.c
+++ b/mts/transport/usb/descriptor.c
@@ -94,3 +94,11 @@ const struct mtp1strings_s mtp1strings = {
       MTP_STRING_DESCRIPTOR,
    },
 };
+
+const struct usb_functionfs_descs_head_incompatible mtp1descriptors_header_incompatible = {
+  .magic = cpu_to_le32(FUNCTIONFS_DESCRIPTORS_MAGIC),
+  .length = cpu_to_le32(sizeof(struct mtp1_descriptors_s_incompatible)),
+  .fs_count = 4,
+  .hs_count = 4,
+  .ss_count = 0
+};

--- a/mts/transport/usb/mtp1descriptors.h
+++ b/mts/transport/usb/mtp1descriptors.h
@@ -17,14 +17,17 @@ static const char* in_file = "/dev/mtp/ep1";
 static const char* out_file = "/dev/mtp/ep2";
 static const char* interrupt_file = "/dev/mtp/ep3";
 
+struct mtp1_descs_s {
+   struct usb_interface_descriptor intf;
+   struct usb_endpoint_descriptor_no_audio mtp_ep_in;
+   struct usb_endpoint_descriptor_no_audio mtp_ep_out;
+   struct usb_endpoint_descriptor_no_audio mtp_ep_int;
+} __attribute__((packed));
+
 struct mtp1_descriptors_s {
    struct usb_functionfs_descs_head header;
-   struct {
-      struct usb_interface_descriptor intf;
-      struct usb_endpoint_descriptor_no_audio mtp_ep_in;
-      struct usb_endpoint_descriptor_no_audio mtp_ep_out;
-      struct usb_endpoint_descriptor_no_audio mtp_ep_int;
-   } __attribute__((packed)) fs_descs, hs_descs;
+   struct mtp1_descs_s fs_descs;
+   struct mtp1_descs_s hs_descs;
 } __attribute__((packed));
 
 extern const struct mtp1_descriptors_s mtp1descriptors;
@@ -38,5 +41,14 @@ struct mtp1strings_s {
 } __attribute__((packed));
 
 extern const struct mtp1strings_s mtp1strings;
+
+struct mtp1_descriptors_s_incompatible {
+   struct usb_functionfs_descs_head header;
+   // The following field is added to the header in some
+   // android kernels, which breaks compatibility.
+   __le32 ss_count;
+   struct mtp1_descs_s fs_descs;
+   struct mtp1_descs_s hs_descs;
+} __attribute__((packed));
 
 #endif

--- a/mts/transport/usb/mtp1descriptors.h
+++ b/mts/transport/usb/mtp1descriptors.h
@@ -42,13 +42,23 @@ struct mtp1strings_s {
 
 extern const struct mtp1strings_s mtp1strings;
 
+
+struct usb_functionfs_descs_head_incompatible {
+        __le32 magic;
+        __le32 length;
+        __le32 fs_count;
+        __le32 hs_count;
+       // The following field is added to the header in some
+       // android kernels, which breaks compatibility.
+        __le32 ss_count;
+} __attribute__((packed));
+
 struct mtp1_descriptors_s_incompatible {
-   struct usb_functionfs_descs_head header;
-   // The following field is added to the header in some
-   // android kernels, which breaks compatibility.
-   __le32 ss_count;
+   struct usb_functionfs_descs_head_incompatible header;
    struct mtp1_descs_s fs_descs;
    struct mtp1_descs_s hs_descs;
 } __attribute__((packed));
+
+extern const struct usb_functionfs_descs_head_incompatible mtp1descriptors_header_incompatible;
 
 #endif

--- a/mts/transport/usb/mtptransporterusb.cpp
+++ b/mts/transport/usb/mtptransporterusb.cpp
@@ -32,6 +32,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -72,6 +73,40 @@ MTPTransporterUSB::MTPTransporterUSB() : m_ioState(SUSPENDED), m_containerReadLe
         this, SLOT(handleDataReady()), Qt::QueuedConnection);
 }
 
+bool MTPTransporterUSB::writeMtpDescriptors()
+{
+    if (write(m_ctrlFd, &mtp1descriptors, sizeof mtp1descriptors) >= 0)
+        return true;
+
+    if (errno == EINVAL) {
+        MTP_LOG_WARNING("Kernel did not accept endpoint descriptors;"
+            " trying 'ss_count' workaround");
+        // Some android kernels changed the usb_functionfs_descs_head size
+        // by adding an ss_count member. Try it that way.
+        struct mtp1_descriptors_s_incompatible descs;
+        descs.header = mtp1descriptors.header;
+        descs.ss_count = 0;
+        descs.fs_descs = mtp1descriptors.fs_descs;
+        descs.hs_descs = mtp1descriptors.hs_descs;
+        if (write(m_ctrlFd, &descs, sizeof descs) >= 0)
+            return true;
+    }
+
+    MTP_LOG_CRITICAL("Couldn't write descriptors to control endpoint file"
+        << control_file);
+    return false;
+}
+
+bool MTPTransporterUSB::writeMtpStrings()
+{
+    if (write(m_ctrlFd, &mtp1strings, sizeof(mtp1strings)) >= 0)
+        return true;
+
+    MTP_LOG_CRITICAL("Couldn't write strings to control endpoint file"
+        << control_file);
+    return false;
+}
+
 bool MTPTransporterUSB::activate()
 {
     MTP_LOG_CRITICAL("MTPTransporterUSB::activate");
@@ -84,23 +119,9 @@ bool MTPTransporterUSB::activate()
     }
     else
     {
-        if(-1 == write(m_ctrlFd, &mtp1descriptors, sizeof mtp1descriptors))
-        {
-            MTP_LOG_CRITICAL("Couldn't write descriptors to control endpoint file "
-                << control_file);
-        }
-        else
-        {
-            if(-1 == write(m_ctrlFd, &mtp1strings, sizeof(mtp1strings)))
-            {
-                MTP_LOG_CRITICAL("Couldn't write strings to control endpoint file "
-                    << control_file);
-            }
-            else
-            {
-                success = true;
-                MTP_LOG_INFO("mtp function set up");
-            }
+        if (writeMtpDescriptors() && writeMtpStrings()) {
+            success = true;
+            MTP_LOG_INFO("mtp function set up");
         }
     }
 

--- a/mts/transport/usb/mtptransporterusb.cpp
+++ b/mts/transport/usb/mtptransporterusb.cpp
@@ -83,9 +83,8 @@ bool MTPTransporterUSB::writeMtpDescriptors()
             " trying 'ss_count' workaround");
         // Some android kernels changed the usb_functionfs_descs_head size
         // by adding an ss_count member. Try it that way.
-        struct mtp1_descriptors_s_incompatible descs;
-        descs.header = mtp1descriptors.header;
-        descs.ss_count = 0;
+        mtp1_descriptors_s_incompatible descs;
+        descs.header = mtp1descriptors_header_incompatible;
         descs.fs_descs = mtp1descriptors.fs_descs;
         descs.hs_descs = mtp1descriptors.hs_descs;
         if (write(m_ctrlFd, &descs, sizeof descs) >= 0)

--- a/mts/transport/usb/mtptransporterusb.h
+++ b/mts/transport/usb/mtptransporterusb.h
@@ -93,6 +93,8 @@ class MTPTransporterUSB : public MTPTransporter
 
     private:
         void processReceivedData();  // Helper function for handleDataReady()
+        bool writeMtpDescriptors();  // configure the USB endpoints for functionfs
+        bool writeMtpStrings();      // step 2 of functionfs configuration
 
         enum IOState{
             ACTIVE,


### PR DESCRIPTION
There's an ad-hoc kernel patch for superspeed support that breaks the API, which is different from how it's supported upstream.

We don't use superspeed either way yet so our only concern needs to be compatibility.

Working around this so that Sailfish can support MTP on affected kernels.
